### PR TITLE
Add manifest.yml and .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,4 @@
+node_modules/
+*.txt
+.env
+*.webm

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: choirless-api
+  memory: 512M
+  disk_quota: 512M
+  buildpack: nodejs_buildpack
+  command: npm run server
+  env:
+    env_type: production


### PR DESCRIPTION
These `manifest.yml` will configure the instances that the API is deployed to CF.

The `.cfignore` stops us from bundling up locally compiled deps and other resources when we deploy to CF