### PR TITLE
prevent duplicate users being created - fixes issue#15

### DIFF
--- a/postUser.js
+++ b/postUser.js
@@ -42,6 +42,7 @@ const postUser = async (opts) => {
       }
     }
   } else {
+    // new user creation
     if (!opts.name || !opts.password || !opts.email) {
       return {
         body: { ok: false, message: 'missing mandatory parameters name/password/email' },
@@ -49,6 +50,23 @@ const postUser = async (opts) => {
         headers: { 'Content-Type': 'application/json' }
       }
     }
+
+    // first check that user with this email doesn't already exist
+    const query = {
+      selector: {
+        email: opts.email
+      }
+    }
+    const result = await db.find(query)
+    if (result.docs && result.docs.length > 0) {
+      return {
+        body: { ok: false, message: 'duplicate user' },
+        statusCode: 409,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+
+    // create user
     const id = kuuid.id()
     const salt = kuuid.id()
     const now = new Date()

--- a/swagger.yml
+++ b/swagger.yml
@@ -55,6 +55,8 @@ paths:
           description: "Invalid input"
         "404":
           description: "User not found"
+        "409":
+          description: "Duplicate user"
     get:
       tags:
       - "user"

--- a/user.test.js
+++ b/user.test.js
@@ -99,6 +99,26 @@ test('getUser - fetch user', async () => {
   expect(response.body.ok).toBe(true)
 })
 
+test('postUser - create user - duplicate check', async () => {
+  const obj = {
+    name: 'Mavis',
+    email: 'mavis@aol.com',
+    password: 'battenburg'
+  }
+  let response = await postUser(obj)
+  expect(response.statusCode).toBe(200)
+  expect(response.body.ok).toBe(true)
+
+  const obj2 = {
+    name: 'Brenda',
+    email: 'mavis@aol.com',
+    password: 'garibaldi'
+  }
+  response = await postUser(obj2)
+  expect(response.statusCode).toBe(409)
+  expect(response.body.ok).toBe(false)
+})
+
 test('getUser - fetch user - invalid user', async () => {
   const response = await getUser({ userId: 'frank' })
   expect(response.statusCode).toBe(404)


### PR DESCRIPTION
- API returns 409 - Duplicate User when trying to create user with same email address as existing user