### PR TITLE
added queue api

### DIFF
--- a/API.md
+++ b/API.md
@@ -251,7 +251,7 @@ Get a single songpart
 Parameters:
 
 - `choirId` - the id of the choir (required)
-- `songId` - the id of the choir (required)
+- `songId` - the id of the song (required)
 - `partId` - the id of the part (required)
 
 Returns
@@ -271,7 +271,7 @@ Get all parts of a song
 Parameters:
 
 - `choirId` - the id of the choir (required)
-- `songId` - the id of the choir (required)
+- `songId` - the id of the song (required)
 
 Returns
 
@@ -279,5 +279,74 @@ Returns
 {
   ok: true,
   parts: [{ ... part doc ... }, { ... part doc ... }]
+}
+```
+
+## Queue
+
+### POST /queue/songpart
+
+Creates/edits an queue item to process an uploaded song part.
+
+Parameters (new queue item):
+
+- `choirId` - the id of the choir (required)
+- `songId` - the id of the song (required)
+- `partId` - the id of the part (required)
+
+Parameters (edit queue item):
+
+- `id` - the id of the queue item (required)
+- `status` - the status `new`/`inprogress`/`complete` (required)
+
+
+Returns
+
+```js
+{
+  ok: true,
+  id: "<id>"
+}
+```
+
+### POST /queue/mixdown
+
+Creates/edits an queue item to perform a mixdown of a song.
+
+Parameters (new queue item):
+
+- `choirId` - the id of the choir (required)
+- `songId` - the id of the song (required)
+
+Parameters (edit queue item):
+
+- `id` - the id of the queue item (required)
+- `status` - the status `new`/`inprogress`/`complete` (required)
+
+
+Returns
+
+```js
+{
+  ok: true,
+  id: "<id>"
+}
+```
+
+
+### GET /queue
+
+Get a queue item by id.
+
+Parameters:
+
+- `id` - the id of the queue item (required)
+
+Returns
+
+```js
+{
+  ok: true,
+  queueItem: { ... }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following environment variables configure how the API accesses the database
 - `COUCH_USERS_DATABASE` - the name of the users database, storing registered Choirless users.
 - `COUCH_CHOIRLESS_DATABASE` - the name of the main choirless database (stores choirs/members/songs/parts).
 - `COUCH_KEYS_DATABASE` - the name of the database for storing API access keys.
+- `COUCH_QUEUE_DATABASE` - the nane of the database to store queued requests
 
 ### W3ID Environment Variables
 
@@ -210,3 +211,46 @@ partType:
 - `backing` - backing track
 - `reference` - exemplar rendition of part
 - `rendition` - choir members rendition of a reference part
+
+### Queue
+
+A queue item can take two forms:
+
+When a new part is uploaded a queue item is created to:
+
+- convert webm files to mp4
+- extract the audio
+- generate a thumbnail image of the video
+
+```js
+{
+   _id: "<kuuid>",
+  type: "songpart",
+  status: "new".  // one of new/inprogress/complete
+  choirId: "<choirid>",
+  songId: "<songid>",
+  partId: "<partid>",
+  partName: "alto",
+  partType: "rendition",
+  createdBy: "<userid>",
+  name: "Glynn Bird",
+  createdOn: "2020-05-01",
+  offset: 0
+}
+```
+
+or when the user wishes to render a song, an item is added to a queue so that
+
+- all audio files are mixed down into combined audio file
+- all video clips are mixed with the audio to produce final mp4 video
+
+```js
+{
+   _id: "<kuuid>",
+  type: "mixdown",
+  status: "new".  // one of new/inprogress/complete
+  choirId: "<choirid>",
+  songId: "<songid>",
+  createdOn: "2020-05-01"
+}
+```

--- a/getQueue.js
+++ b/getQueue.js
@@ -1,0 +1,47 @@
+const Nano = require('nano')
+const debug = require('debug')('choirless')
+let nano = null
+let db = null
+
+// fetch a queue item by known id
+// Parameters:
+// - `id` - the queue item to fetch
+const getQueue = async (opts) => {
+  // connect to db - reuse connection if present
+  if (!db) {
+    nano = Nano(process.env.COUCH_URL)
+    db = nano.db.use(process.env.COUCH_QUEUE_DATABASE)
+  }
+
+  // extract parameters
+  const id = opts.id
+  if (!id) {
+    return {
+      body: { ok: false, message: 'missing mandatory parameter id' },
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' }
+    }
+  }
+
+  // fetch queue item from database
+  let statusCode = 200
+  let body = null
+  try {
+    debug('getQueue', id)
+    const qi = await db.get(id)
+    delete qi._rev
+    body = { ok: true, queueItem: qi }
+  } catch (e) {
+    body = { ok: false, message: 'queue item not found' }
+    statusCode = 404
+  }
+
+  // return API response
+  return {
+    body: body,
+    statusCode: statusCode,
+    headers: { 'Content-Type': 'application/json' }
+  }
+}
+
+module.exports = getQueue

--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,11 +6279,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
-    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",

--- a/postQueueMixdown.js
+++ b/postQueueMixdown.js
@@ -1,0 +1,92 @@
+const Nano = require('nano')
+const debug = require('debug')('choirless')
+const kuuid = require('kuuid')
+let nano = null
+let db = null
+let qdb = null
+
+// queue a song part for mixdown
+// Parameters (add):
+// - `choirId` - the id of the choir (required)
+// - `songId` - the id of the song (required)
+// Parameters (update):
+// - `id` - the id of the queue item (required)
+// - `status` - the status of the queue item (required)
+const postQueueMixdown = async (opts) => {
+  // connect to db - reuse connection if present
+  if (!db) {
+    nano = Nano(process.env.COUCH_URL)
+    db = nano.db.use(process.env.COUCH_CHOIRLESS_DATABASE)
+    qdb = nano.db.use(process.env.COUCH_QUEUE_DATABASE)
+  }
+
+  // extract parameters
+  let doc = {}
+  let statusCode = 200
+  let body = {}
+
+  // is this a request to edit an existing queue item
+  if (opts.id && opts.status) {
+    // check for mandatory parameters
+    if (!['new', 'inprogress', 'complete'].includes(opts.status)) {
+      return {
+        body: { ok: false, message: 'invalid status' },
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+
+    try {
+      debug('postQueueMixdown fetch queue item', opts.id)
+      doc = await qdb.get(opts.id)
+      doc.status = opts.status
+      debug('postQueueMixdown update queue item', opts.id)
+      await qdb.insert(doc)
+      statusCode = 200
+      body = { ok: true, id: opts.id }
+    } catch (e) {
+      return {
+        body: { ok: false, message: 'song part not found' },
+        statusCode: 404,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+  } else {
+    // check for mandatory parameters
+    if (!opts.choirId || !opts.songId) {
+      return {
+        body: { ok: false, message: 'missing mandatory parameters' },
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+
+    try {
+      // fetch the sing - if it doesn't exist, no queue item is created
+      const doc = await db.get(opts.choirId + ':song:' + opts.songId)
+
+      // create queue item
+      delete doc._id
+      delete doc._rev
+      doc.type = 'mixdown'
+      doc.status = 'new'
+      doc._id = kuuid.id()
+      debug('postQueueMixdown write queue item', doc)
+      await qdb.insert(doc)
+      statusCode = 200
+      body = { ok: true, id: doc._id }
+    } catch (e) {
+      body = { ok: false, err: 'Failed to create queue item' }
+      statusCode = 404
+    }
+  }
+
+  // return API response
+  return {
+    body: body,
+    statusCode: statusCode,
+    headers: { 'Content-Type': 'application/json' }
+  }
+}
+
+module.exports = postQueueMixdown

--- a/postQueueSongPart.js
+++ b/postQueueSongPart.js
@@ -1,0 +1,94 @@
+const Nano = require('nano')
+const debug = require('debug')('choirless')
+const kuuid = require('kuuid')
+let nano = null
+let db = null
+let qdb = null
+
+// queue a song part for post-processing
+// Parameters (add):
+// - `choirId` - the id of the choir (required)
+// - `songId` - the id of the song (required)
+// - `partId` - the id of the part (required for updates, if omitted a new song part is created)
+// Parameters (update):
+// - `id` - the id of the queue item (required)
+// - `status` - the status of the queue item (required)
+const postQueueSongPart = async (opts) => {
+  // connect to db - reuse connection if present
+  if (!db) {
+    nano = Nano(process.env.COUCH_URL)
+    db = nano.db.use(process.env.COUCH_CHOIRLESS_DATABASE)
+    qdb = nano.db.use(process.env.COUCH_QUEUE_DATABASE)
+  }
+
+  // extract parameters
+  let doc = {}
+  let statusCode = 200
+  let body = {}
+
+  // is this a request to edit an existing queue item
+  if (opts.id && opts.status) {
+    // check for mandatory parameters
+    if (!['new', 'inprogress', 'complete'].includes(opts.status)) {
+      return {
+        body: { ok: false, message: 'invalid status' },
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+
+    try {
+      debug('postQueueSongPart fetch queue item', opts.id)
+      doc = await qdb.get(opts.id)
+      doc.status = opts.status
+      debug('postQueueSongPart update queue item', opts.id)
+      await qdb.insert(doc)
+      statusCode = 200
+      body = { ok: true, id: opts.id }
+    } catch (e) {
+      return {
+        body: { ok: false, message: 'song part not found' },
+        statusCode: 404,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+  } else {
+    // check for mandatory parameters
+    if (!opts.choirId || !opts.songId || !opts.partId) {
+      return {
+        body: { ok: false, message: 'missing mandatory parameters' },
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+
+    try {
+      // fetch the part - if it doesn't exist, no queue item is created
+      const doc = await db.get(opts.choirId + ':song:' + opts.songId + ':part:' + opts.partId)
+
+      // create queue item
+      delete doc._id
+      delete doc._rev
+      doc.partId = opts.partId
+      doc.type = 'songpart'
+      doc.status = 'new'
+      doc._id = kuuid.id()
+      debug('postQueueSongPart write queue item', doc)
+      await qdb.insert(doc)
+      statusCode = 200
+      body = { ok: true, id: doc._id }
+    } catch (e) {
+      body = { ok: false, err: 'Failed to create queue item' }
+      statusCode = 404
+    }
+  }
+
+  // return API response
+  return {
+    body: body,
+    statusCode: statusCode,
+    headers: { 'Content-Type': 'application/json' }
+  }
+}
+
+module.exports = postQueueSongPart

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ const port = process.env.PORT || 3000
 const app = express()
 const morgan = require('morgan')
 const w3id = require('w3id-middleware')
-
 const whitelist = require('./whitelist.js')
 const keyProtect = require('./checkAPIKey.js')
 
@@ -30,6 +29,9 @@ const postChoirSong = require('./postChoirSong.js')
 const postChoirSongPart = require('./postChoirSongPart.js')
 const getChoirSongPart = require('./getChoirSongPart.js')
 const getChoirSongParts = require('./getChoirSongParts.js')
+const postQueueMixdown = require('./postQueueMixdown.js')
+const postQueueSongPart = require('./postQueueSongPart.js')
+const getQueue = require('./getQueue.js')
 
 // Health endpoint
 app.get('/__gtg', async (req, res) => {
@@ -108,6 +110,21 @@ app.get('/choir/songparts', [keyProtect], async (req, res) => {
 
 app.get('/choir/songpart', [keyProtect], async (req, res) => {
   const response = await getChoirSongPart(req.query)
+  res.status(response.statusCode).send(response.body)
+})
+
+app.post('/queue/songpart', [keyProtect], async (req, res) => {
+  const response = await postQueueSongPart(req.body)
+  res.status(response.statusCode).send(response.body)
+})
+
+app.post('/queue/mixdown', [keyProtect], async (req, res) => {
+  const response = await postQueueMixdown(req.body)
+  res.status(response.statusCode).send(response.body)
+})
+
+app.get('/queue', [keyProtect], async (req, res) => {
+  const response = await getQueue(req.query)
   res.status(response.statusCode).send(response.body)
 })
 

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,13 @@ curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["email"]},"name":"byEmail"}' 
 curl -X PUT "${COUCH_URL}/${COUCH_CHOIRLESS_DATABASE}?partitioned=true"
 
 # create choirless keys database (unpartitioned)
-curl -X PUT "${COUCH_URL}/${COUCH_KEYS_DATABASE}?partitioned=false"
+curl -X PUT "${COUCH_URL}/${COUCH_KEYS_DATABASE}"
 
 # create a secondary indexes
 curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["type"]},"name":"byType","partitioned":true}' "${COUCH_URL}/${COUCH_CHOIRLESS_DATABASE}/_index"
 curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["userId","type"]},"name":"byUserIdType","partitioned":false}' "${COUCH_URL}/${COUCH_CHOIRLESS_DATABASE}/_index"
+
+# create queue database (unpartitioned)
+curl -X PUT "${COUCH_URL}/${COUCH_QUEUE_DATABASE}"
+# create a secondary indexes
+# curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["type","status"]},"name":"byStatus"}' "${COUCH_URL}/${COUCH_QUEUE_DATABASE}/_index"

--- a/swagger.yml
+++ b/swagger.yml
@@ -15,10 +15,97 @@ tags:
 - name: "choir"
   description: "Choir-related actions"
 - name: "user"
-  description: "User-relqted actions"
+  description: "User-related actions"
+- name: "queue"
+  description: "Queue-related actions"
 schemes:
 - "http"
 paths:
+  /queue:
+    get:
+      tags:
+      - "queue"
+      summary: "Get a queue item "
+      description: "Fetch a queue item  by its id"
+      operationId: "getQueue"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: query
+        type: string
+        name: id
+        required: true
+      responses:
+        "200":
+          description: "successful operation"
+        "400":
+          description: "Invalid input"
+        "404":
+          description: "Not found"
+  /queue/songpart:
+    post:
+      tags:
+      - "queue"
+      summary: "Add/Edit a queue item for a song part"
+      description: ""
+      operationId: "postQueueSongPart"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Queue object to be added"
+        required: true
+        schema:
+          type: object
+          properties:
+            choirId:
+              type: string
+            songId:
+              type: string
+            partId:
+              type: string
+      responses:
+        "200":
+          description: "successful operation"
+        "400":
+          description: "Invalid input"
+        "404":
+          description: "Not found"
+  /queue/mixdown:
+    post:
+      tags:
+      - "queue"
+      summary: "Add/Edit a queue item for a mixdown"
+      description: ""
+      operationId: "postQueueMixdown"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Queue object to be added"
+        required: true
+        schema:
+          type: object
+          properties:
+            choirId:
+              type: string
+            songId:
+              type: string
+      responses:
+        "200":
+          description: "successful operation"
+        "400":
+          description: "Invalid input"
+        "404":
+          description: "Not found"
   /user:
     post:
       tags:

--- a/user.test.js
+++ b/user.test.js
@@ -8,7 +8,7 @@ const nano = Nano(COUCH_URL)
 // the code we're testing
 process.env.COUCH_URL = COUCH_URL
 process.env.COUCH_USERS_DATABASE = DB1
-process.env.COUCH_CHOIRLESS_DATABASE = DB1
+process.env.COUCH_CHOIRLESS_DATABASE = DB2
 const postUser = require('./postUser.js')
 const postUserLogin = require('./postUserLogin.js')
 const getUser = require('./getUser.js')


### PR DESCRIPTION
Three new endpoints:

- `POST /queue/songpart` - to queue up a song part for post-processing
- `POST /queue/mixdown` - to queue up a song for final mixdown
- `GET /queue` - to check on a queue item

Both `POST` APIs allow the creation and update of queue items.

Updated API.md and README.md to reflect this. 
