### PR TITLE
add frontendOffset to songpart - fixes issue #49

### DIFF
--- a/API.md
+++ b/API.md
@@ -290,6 +290,7 @@ Parameters:
 - `userId` - the id of the user (required for new parts)
 - `userName` - the name of the user (required for new parts)
 - `offset` - the number of milliseconds after the reference part that this recording started (default 0)
+- `frontendOffset` - the number of milliseconds after the reference part that this recording started according to the user (default 0)
 - `aspectRadio` - the aspect ratio of the video e.g. `4:3`
 - `hidden` - boolean indicating whether this part is to be hidden in the final mix e.g. `false`
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ memberType:
   createdBy: "<userid>",
   name: "Glynn Bird",
   createdOn: "2020-05-01",
-  offset: 0,
+  offset: 200,
+  frontendOffset: 150,
   aspectRatio: "4:3",
   hidden: false
 }

--- a/choir.test.js
+++ b/choir.test.js
@@ -604,6 +604,7 @@ test('postChoirSongPart - update part', async () => {
   expect(response.body.part.partName).toBe('tenor')
   expect(response.body.part.partType).toBe('reference')
   expect(response.body.part.offset).toBe(0)
+  expect(response.body.part.frontendOffset).toBe(0)
   const doc = response.body.part
   doc.partId = part1
 
@@ -617,6 +618,7 @@ test('postChoirSongPart - update part', async () => {
   expect(response.body.part.partName).toBe('tenor')
   expect(response.body.part.partType).toBe('reference')
   expect(response.body.part.offset).toBe(150)
+  expect(response.body.part.frontendOffset).toBe(0)
 
   // edit partType
   doc.partType = 'backing'
@@ -631,6 +633,7 @@ test('postChoirSongPart - update part', async () => {
   expect(response.body.part.offset).toBe(150)
   expect(response.body.part.aspectRatio).toBe('400:300')
   expect(response.body.part.hidden).toBe(false)
+  expect(response.body.part.frontendOffset).toBe(0)
 
   // edit hidden
   doc.hidden = true
@@ -644,6 +647,21 @@ test('postChoirSongPart - update part', async () => {
   expect(response.body.part.offset).toBe(150)
   expect(response.body.part.aspectRatio).toBe('400:300')
   expect(response.body.part.hidden).toBe(true)
+  expect(response.body.part.frontendOffset).toBe(0)
+
+  // edit hidden
+  doc.frontendOffset = 200
+  response = await postChoirSongPart(doc)
+  expect(response.body.ok).toBe(true)
+  response = await getChoirSongPart({ choirId: london, songId: song1, partId: part1 })
+  expect(response.body.ok).toBe(true)
+  expect(response.body.part.userName).toBe('Rita')
+  expect(response.body.part.partName).toBe('tenor')
+  expect(response.body.part.partType).toBe('backing')
+  expect(response.body.part.offset).toBe(150)
+  expect(response.body.part.aspectRatio).toBe('400:300')
+  expect(response.body.part.hidden).toBe(true)
+  expect(response.body.part.frontendOffset).toBe(200)
 })
 
 test('getChoirSongParts - get all parts', async () => {

--- a/postChoirSongPart.js
+++ b/postChoirSongPart.js
@@ -34,6 +34,7 @@ const postChoirSongPart = async (opts) => {
       doc = await db.get(id)
       doc.partType = opts.partType ? opts.partType : doc.partType
       doc.offset = typeof opts.offset === 'number' ? opts.offset : doc.offset
+      doc.frontendOffset = typeof opts.frontendOffset === 'number' ? opts.frontendOffset : doc.frontendOffset || 0
       doc.aspectRatio = opts.aspectRatio ? opts.aspectRatio : doc.aspectRatio
       doc.hidden = typeof opts.hidden === 'boolean' ? opts.hidden : doc.hidden || false
       partId = opts.partId
@@ -66,6 +67,7 @@ const postChoirSongPart = async (opts) => {
       partName: opts.partName || '',
       partType: opts.partType || 'backing',
       offset: opts.offset || 0,
+      frontendOffset: opts.frontendOffset || 0,
       aspectRatio: opts.aspectRatio || '',
       hidden: false
     }


### PR DESCRIPTION
- POST /choir/songpart has new `frontendOffset` field (integer)
- API docs & README updated