### PR TITLE
allow render status to be used for reporting too

### DIFF
--- a/API.md
+++ b/API.md
@@ -439,8 +439,12 @@ Error responses
 
 ### POST /render
 
+Update the status of a render job.
+
 Parameters:
 
+- `choirId` - the id of the choir (required)
+- `songId` - the id of the song (required)
 - `partId` - the id of song part that triggered the render (required)
 - `status` - one of `new`/`converted`/`aligned`/`rendered`/`composited`/`done` (default `new`)
 
@@ -454,8 +458,12 @@ Returns:
 
 ### GET /render
 
+Check the status of a render job.
+
 Parameters:
 
+- `choirId` - the id of the choir (required)
+- `songId` - the id of the song (required)
 - `partId` - the id of song part that triggered the render (required)
 
 Returns:
@@ -464,8 +472,35 @@ Returns:
 {
    ok: true,
    render: {
+      choirId: 'x',
+      songId: 'y',
+      partId: 'z',
       status: 'new',
       date: '2020-08-29T10:20:59.000Z'
    }
+}
+```
+
+### GET /render/done
+
+Get completed render jobs for a given song. Returns up to fifty render jobs - newest first.
+
+Parameters:
+
+- `choirId` - the id of the choir (required)
+- `songId` - the id of the song (required)
+
+Returns:
+
+```js
+{
+   ok: true,
+   renders: [{
+      choirId: 'x',
+      songId: 'y',
+      partId: 'z',
+      status: 'new',
+      date: '2020-08-29T10:20:59.000Z'
+   }]
 }
 ```

--- a/API.md
+++ b/API.md
@@ -464,7 +464,7 @@ Parameters:
 
 - `choirId` - the id of the choir (required)
 - `songId` - the id of the song (required)
-- `partId` - the id of song part that triggered the render (required)
+- `partId` - the id of song part that triggered the render
 
 Returns:
 
@@ -474,7 +474,7 @@ Returns:
    render: {
       choirId: 'x',
       songId: 'y',
-      partId: 'z',
+      partId: 'z', // or null
       status: 'new',
       date: '2020-08-29T10:20:59.000Z'
    }

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ This records progress of the rendering process:
 
 ```js
 {
+  choirId: '<id of choir whose song is being rendererd>',
+  songId: '<id of song being rendererd>',
   partId: "<id of the part that triggered the render>",
   status: "new", // one of new/converted/aligned/rendered/composited/done
   date: "2020-08-01T10:56:22.000Z"

--- a/getRender.js
+++ b/getRender.js
@@ -15,7 +15,7 @@ const getRender = async (opts) => {
   }
 
   // check mandatory parameters
-  if (!opts.partId || !opts.choirId || !opts.songId) {
+  if (!opts.choirId || !opts.songId) {
     return {
       body: { ok: false, message: 'missing mandatory parameters' },
       statusCode: 400,
@@ -27,11 +27,11 @@ const getRender = async (opts) => {
   let statusCode = 200
   let body = {}
   try {
-    debug('getRender', opts.choirId, opts.songId, opts.partId)
-    const id = [opts.choirId, opts.songId, opts.partId, '\uffff'].join(':')
+    debug('getRender', opts.choirId, opts.songId)
+    const id = [opts.choirId, opts.songId, '\uffff'].join(':')
     const response = await db.list({ startkey: id, descending: true, limit: 1, include_docs: true })
     const doc = response.rows ? response.rows[0].doc : null
-    if (doc && doc.partId === opts.partId) {
+    if (doc && doc.songId === opts.songId) {
       delete doc._id
       delete doc._rev
       body.ok = true

--- a/getRenderDone.js
+++ b/getRenderDone.js
@@ -26,7 +26,7 @@ const getRenderDone = async (opts) => {
   let statusCode = 200
   let body = {}
   try {
-    debug('getRenderDone', opts.choirId, opts.songId, opts.partId)
+    debug('getRenderDone', opts.choirId, opts.songId)
     const query = {
       selector: {
         status: 'done',
@@ -36,7 +36,7 @@ const getRenderDone = async (opts) => {
       sort: [
         { choirId: 'desc' },
         { songId: 'desc' },
-        { partId: 'desc' }
+        { date: 'desc' }
       ],
       limit: 50,
       use_index: 'find/completedRenders',

--- a/getRenderDone.js
+++ b/getRenderDone.js
@@ -3,11 +3,10 @@ const debug = require('debug')('choirless')
 let nano = null
 let db = null
 
-// get render status
+// get render done
 // choirId - the id of the choir
 // songId - the id of the song
-// partId - the id of part the triggered the render
-const getRender = async (opts) => {
+const getRenderDone = async (opts) => {
   // connect to db - reuse connection if present
   if (!db) {
     nano = Nano(process.env.COUCH_URL)
@@ -15,7 +14,7 @@ const getRender = async (opts) => {
   }
 
   // check mandatory parameters
-  if (!opts.partId || !opts.choirId || !opts.songId) {
+  if (!opts.choirId || !opts.songId) {
     return {
       body: { ok: false, message: 'missing mandatory parameters' },
       statusCode: 400,
@@ -27,21 +26,26 @@ const getRender = async (opts) => {
   let statusCode = 200
   let body = {}
   try {
-    debug('getRender', opts.choirId, opts.songId, opts.partId)
-    const id = [opts.choirId, opts.songId, opts.partId, '\uffff'].join(':')
-    const response = await db.list({ startkey: id, descending: true, limit: 1, include_docs: true })
-    const doc = response.rows ? response.rows[0].doc : null
-    if (doc && doc.partId === opts.partId) {
-      delete doc._id
-      delete doc._rev
-      body.ok = true
-      body.render = doc
-    } else {
-      body.ok = false
-      statusCode = 404
+    debug('getRenderDone', opts.choirId, opts.songId, opts.partId)
+    const query = {
+      selector: {
+        status: 'done',
+        choirId: opts.choirId,
+        songId: opts.songId
+      },
+      sort: [
+        { choirId: 'desc' },
+        { songId: 'desc' },
+        { partId: 'desc' }
+      ],
+      limit: 50,
+      use_index: 'find/completedRenders',
+      execution_stats: true
     }
+    const result = await db.find(query)
+    body.renders = result.docs.map((d) => { delete d._id; delete d._rev; return d })
   } catch (e) {
-    body = { ok: false, err: 'Failed to fetch render' }
+    body = { ok: false, err: 'Failed to fetch completed renders' }
     statusCode = 404
   }
 
@@ -53,4 +57,4 @@ const getRender = async (opts) => {
   }
 }
 
-module.exports = getRender
+module.exports = getRenderDone

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const getInvitationList = require('./getInvitationList.js')
 const deleteInvitation = require('./deleteInvitation.js')
 const postRender = require('./postRender.js')
 const getRender = require('./getRender.js')
+const getRenderDone = require('./getRenderDone.js')
 
 module.exports = {
   getUser: arg => wrapper(getUser, arg),
@@ -61,5 +62,6 @@ module.exports = {
   getInvitationList: arg => wrapper(getInvitationList, arg),
   deleteInvitation: arg => wrapper(deleteInvitation, arg),
   postRender: arg => wrapper(postRender, arg),
-  getRender: arg => wrapper(getRender, arg)
+  getRender: arg => wrapper(getRender, arg),
+  getRenderDone: arg => wrapper(getRenderDone, arg)
 }

--- a/postRender.js
+++ b/postRender.js
@@ -5,6 +5,8 @@ let nano = null
 let db = null
 
 // create a render status object
+// choirId - the id of the choir
+// songId - the id of the song
 // partId - the id of the part the triggered the render
 // status - the status of the render new/converted/aligned/rendered/composited/done
 const postRender = async (opts) => {
@@ -15,7 +17,7 @@ const postRender = async (opts) => {
   }
 
   // check for mandatory fields
-  if (!opts.partId) {
+  if (!opts.partId || !opts.choirId || !opts.songId) {
     return {
       body: { ok: false, message: 'missing mandatory fields' },
       statusCode: 400,
@@ -40,7 +42,9 @@ const postRender = async (opts) => {
   let body = {}
   try {
     const doc = {
-      _id: [opts.partId, kuuid.id()].join(':'),
+      _id: [opts.choirId, opts.songId, opts.partId, kuuid.id()].join(':'),
+      choirId: opts.choirId,
+      songId: opts.songId,
       partId: opts.partId,
       status: opts.status,
       date: new Date().toISOString()

--- a/postRender.js
+++ b/postRender.js
@@ -17,7 +17,7 @@ const postRender = async (opts) => {
   }
 
   // check for mandatory fields
-  if (!opts.partId || !opts.choirId || !opts.songId) {
+  if (!opts.choirId || !opts.songId) {
     return {
       body: { ok: false, message: 'missing mandatory fields' },
       statusCode: 400,
@@ -42,10 +42,10 @@ const postRender = async (opts) => {
   let body = {}
   try {
     const doc = {
-      _id: [opts.choirId, opts.songId, opts.partId, kuuid.id()].join(':'),
+      _id: [opts.choirId, opts.songId, kuuid.id()].join(':'),
       choirId: opts.choirId,
       songId: opts.songId,
-      partId: opts.partId,
+      partId: opts.partId || null,
       status: opts.status,
       date: new Date().toISOString()
     }

--- a/render.test.js
+++ b/render.test.js
@@ -36,7 +36,6 @@ test('postRender - missing parameters #1', async () => {
 
 test('postRender - missing parameters #2', async () => {
   const obj = {
-    choirId: 'a',
     songId: 'b'
   }
   const response = await postRender(obj)
@@ -65,15 +64,15 @@ test('postRender - create render status', async () => {
 
   obj = {
     choirId: 'a',
-    songId: 'b',
-    partId: 'mno456'
+    songId: 'c',
+    partId: ''
   }
   response = await postRender(obj)
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
 
   await sleep(1000)
-  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -81,7 +80,7 @@ test('postRender - create render status', async () => {
 })
 
 test('getRender - check non-existant song', async () => {
-  const response = await getRender({ choirId: 'a', songId: 'b', partId: 'nothing' })
+  const response = await getRender({ choirId: 'a', songId: 'nothing' })
   expect(response.statusCode).toBe(404)
   expect(response.body.ok).toBe(false)
 })
@@ -97,7 +96,7 @@ test('postRender - updater status #1', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -115,7 +114,7 @@ test('postRender - updater status #2', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -133,7 +132,7 @@ test('postRender - updater status #3', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -144,14 +143,13 @@ test('postRender - updater status #4', async () => {
   const obj = {
     choirId: 'a',
     songId: 'b',
-    partId: 'xyz789',
     status: 'done'
   }
   let response = await postRender(obj)
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')

--- a/render.test.js
+++ b/render.test.js
@@ -27,7 +27,7 @@ afterAll(async () => {
 
 test('postRender - missing parameters #1', async () => {
   const obj = {
-    choirId: 'xyz123'
+    choirId: 'a'
   }
   const response = await postRender(obj)
   expect(response.statusCode).toBe(400)
@@ -36,6 +36,8 @@ test('postRender - missing parameters #1', async () => {
 
 test('postRender - missing parameters #2', async () => {
   const obj = {
+    choirId: 'a',
+    songId: 'b'
   }
   const response = await postRender(obj)
   expect(response.statusCode).toBe(400)
@@ -44,6 +46,8 @@ test('postRender - missing parameters #2', async () => {
 
 test('postRender - create render status', async () => {
   let obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'xyz789'
   }
   let response = await postRender(obj)
@@ -51,6 +55,8 @@ test('postRender - create render status', async () => {
   expect(response.body.ok).toBe(true)
 
   obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'abc123'
   }
   response = await postRender(obj)
@@ -58,6 +64,8 @@ test('postRender - create render status', async () => {
   expect(response.body.ok).toBe(true)
 
   obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'mno456'
   }
   response = await postRender(obj)
@@ -65,7 +73,7 @@ test('postRender - create render status', async () => {
   expect(response.body.ok).toBe(true)
 
   await sleep(1000)
-  response = await getRender({ partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -73,13 +81,15 @@ test('postRender - create render status', async () => {
 })
 
 test('getRender - check non-existant song', async () => {
-  const response = await getRender({ partId: 'nothing' })
+  const response = await getRender({ choirId: 'a', songId: 'b', partId: 'nothing' })
   expect(response.statusCode).toBe(404)
   expect(response.body.ok).toBe(false)
 })
 
 test('postRender - updater status #1', async () => {
   const obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'xyz789',
     status: 'converted'
   }
@@ -87,7 +97,7 @@ test('postRender - updater status #1', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -96,6 +106,8 @@ test('postRender - updater status #1', async () => {
 
 test('postRender - updater status #2', async () => {
   const obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'xyz789',
     status: 'aligned'
   }
@@ -103,7 +115,7 @@ test('postRender - updater status #2', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -112,6 +124,8 @@ test('postRender - updater status #2', async () => {
 
 test('postRender - updater status #3', async () => {
   const obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'xyz789',
     status: 'rendered'
   }
@@ -119,7 +133,7 @@ test('postRender - updater status #3', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -128,6 +142,8 @@ test('postRender - updater status #3', async () => {
 
 test('postRender - updater status #4', async () => {
   const obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'xyz789',
     status: 'done'
   }
@@ -135,7 +151,7 @@ test('postRender - updater status #4', async () => {
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   await sleep(1000)
-  response = await getRender({ partId: 'xyz789' })
+  response = await getRender({ choirId: 'a', songId: 'b', partId: 'xyz789' })
   expect(response.statusCode).toBe(200)
   expect(response.body.ok).toBe(true)
   expect(typeof response.body.render).toBe('object')
@@ -144,6 +160,8 @@ test('postRender - updater status #4', async () => {
 
 test('postRender - invalid status', async () => {
   const obj = {
+    choirId: 'a',
+    songId: 'b',
     partId: 'xyz789',
     status: 'sausages'
   }

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ const getInvitationList = require('./getInvitationList.js')
 const deleteInvitation = require('./deleteInvitation.js')
 const postRender = require('./postRender.js')
 const getRender = require('./getRender.js')
+const getRenderDone = require('./getRenderDone.js')
 
 // Health endpoint
 app.get('/__gtg', async (req, res) => {
@@ -177,6 +178,11 @@ app.post('/render', [keyProtect], async (req, res) => {
 
 app.get('/render', [keyProtect], async (req, res) => {
   const response = await getRender(req.query)
+  res.status(response.statusCode).send(response.body)
+})
+
+app.get('/render/done', [keyProtect], async (req, res) => {
+  const response = await getRenderDone(req.query)
   res.status(response.statusCode).send(response.body)
 })
 

--- a/setup.sh
+++ b/setup.sh
@@ -23,4 +23,4 @@ curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["expires"]},"name":"byExpirat
 
 # create render database (unpartitioned)
 curl -X PUT "${COUCH_URL}/${COUCH_RENDER_DATABASE}"
-curl -X POST -H "${CTYPE}" -d'{"ddoc":"find","index":{"partial_filter_selector":{"status":"done"},"fields": ["choirId","songId","partId"]},"name":"completedRenders","partitioned":false}' "${COUCH_URL}/${COUCH_RENDER_DATABASE}/_index"
+curl -X POST -H "${CTYPE}" -d'{"ddoc":"find","index":{"partial_filter_selector":{"status":"done"},"fields": ["choirId","songId","date"]},"name":"completedRenders","partitioned":false}' "${COUCH_URL}/${COUCH_RENDER_DATABASE}/_index"

--- a/setup.sh
+++ b/setup.sh
@@ -23,3 +23,4 @@ curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["expires"]},"name":"byExpirat
 
 # create render database (unpartitioned)
 curl -X PUT "${COUCH_URL}/${COUCH_RENDER_DATABASE}"
+curl -X POST -H "${CTYPE}" -d'{"ddoc":"find","index":{"partial_filter_selector":{"status":"done"},"fields": ["choirId","songId","partId"]},"name":"completedRenders","partitioned":false}' "${COUCH_URL}/${COUCH_INVITATION_DATABASE}/_index"

--- a/setup.sh
+++ b/setup.sh
@@ -23,4 +23,4 @@ curl -X POST -H "${CTYPE}" -d'{"index":{"fields": ["expires"]},"name":"byExpirat
 
 # create render database (unpartitioned)
 curl -X PUT "${COUCH_URL}/${COUCH_RENDER_DATABASE}"
-curl -X POST -H "${CTYPE}" -d'{"ddoc":"find","index":{"partial_filter_selector":{"status":"done"},"fields": ["choirId","songId","partId"]},"name":"completedRenders","partitioned":false}' "${COUCH_URL}/${COUCH_INVITATION_DATABASE}/_index"
+curl -X POST -H "${CTYPE}" -d'{"ddoc":"find","index":{"partial_filter_selector":{"status":"done"},"fields": ["choirId","songId","partId"]},"name":"completedRenders","partitioned":false}' "${COUCH_URL}/${COUCH_RENDER_DATABASE}/_index"


### PR DESCRIPTION
I rethought this a bit. Initially I went with a minimal "partId-only" approach, but it's actually better for the render status API to expect choirId + songId too. The reason is because we can then use it for reporting, so there's a new API call `GET /render/done?choirId=x&songId=y` which returns a reverse time-ordered list of renderings to power the UI on the front end. It only includes renderings that are `status: done`.

Before putting this live, it needs this index: 

https://github.com/Choirless/choirlessapi/blob/renderstatusagain/setup.sh#L26